### PR TITLE
[BUGFIX-1] - Update typing

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'vite';
+import { PluginOption } from 'vite';
 export interface Options {
     /**
      * Output path to hugo build directory.
@@ -9,4 +9,4 @@ export interface Options {
      */
     appDir: string;
 }
-export default function hugoPlugin({ hugoOutDir, appDir }: Options): Plugin;
+export default function hugoPlugin({ hugoOutDir, appDir }: Options): PluginOption;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,36 @@
 {
   "name": "vite-hugo-plugin",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-hugo-plugin",
-      "version": "1.0.7",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.11",
         "toml": "^3.0.0",
-        "vite": "^2.9.11"
+        "vite": "^3.0.4"
       },
       "devDependencies": {
         "@types/node": "^17.0.42",
         "typescript": "^4.7.3"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.53.tgz",
+      "integrity": "sha512-W2dAL6Bnyn4xa/QRSU3ilIK4EzD5wgYXKXJiS1HDF5vU3675qc2bvFyLwbUcdmssDveyndy7FbitrCoiV/eMLg==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -68,9 +83,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.43.tgz",
-      "integrity": "sha512-Uf94+kQmy/5jsFwKWiQB4hfo/RkM9Dh7b79p8yqd1tshULdr25G2szLz631NoH3s2ujnKEKVD16RmOxvCNKRFA==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.53.tgz",
+      "integrity": "sha512-ohO33pUBQ64q6mmheX1mZ8mIXj8ivQY/L4oVuAshr+aJI+zLl+amrp3EodrUNDNYVrKJXGPfIHFGhO8slGRjuw==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -79,32 +94,33 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "esbuild-android-64": "0.14.43",
-        "esbuild-android-arm64": "0.14.43",
-        "esbuild-darwin-64": "0.14.43",
-        "esbuild-darwin-arm64": "0.14.43",
-        "esbuild-freebsd-64": "0.14.43",
-        "esbuild-freebsd-arm64": "0.14.43",
-        "esbuild-linux-32": "0.14.43",
-        "esbuild-linux-64": "0.14.43",
-        "esbuild-linux-arm": "0.14.43",
-        "esbuild-linux-arm64": "0.14.43",
-        "esbuild-linux-mips64le": "0.14.43",
-        "esbuild-linux-ppc64le": "0.14.43",
-        "esbuild-linux-riscv64": "0.14.43",
-        "esbuild-linux-s390x": "0.14.43",
-        "esbuild-netbsd-64": "0.14.43",
-        "esbuild-openbsd-64": "0.14.43",
-        "esbuild-sunos-64": "0.14.43",
-        "esbuild-windows-32": "0.14.43",
-        "esbuild-windows-64": "0.14.43",
-        "esbuild-windows-arm64": "0.14.43"
+        "@esbuild/linux-loong64": "0.14.53",
+        "esbuild-android-64": "0.14.53",
+        "esbuild-android-arm64": "0.14.53",
+        "esbuild-darwin-64": "0.14.53",
+        "esbuild-darwin-arm64": "0.14.53",
+        "esbuild-freebsd-64": "0.14.53",
+        "esbuild-freebsd-arm64": "0.14.53",
+        "esbuild-linux-32": "0.14.53",
+        "esbuild-linux-64": "0.14.53",
+        "esbuild-linux-arm": "0.14.53",
+        "esbuild-linux-arm64": "0.14.53",
+        "esbuild-linux-mips64le": "0.14.53",
+        "esbuild-linux-ppc64le": "0.14.53",
+        "esbuild-linux-riscv64": "0.14.53",
+        "esbuild-linux-s390x": "0.14.53",
+        "esbuild-netbsd-64": "0.14.53",
+        "esbuild-openbsd-64": "0.14.53",
+        "esbuild-sunos-64": "0.14.53",
+        "esbuild-windows-32": "0.14.53",
+        "esbuild-windows-64": "0.14.53",
+        "esbuild-windows-arm64": "0.14.53"
       }
     },
     "node_modules/esbuild-android-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.43.tgz",
-      "integrity": "sha512-kqFXAS72K6cNrB6RiM7YJ5lNvmWRDSlpi7ZuRZ1hu1S3w0zlwcoCxWAyM23LQUyZSs1PbjHgdbbfYAN8IGh6xg==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.53.tgz",
+      "integrity": "sha512-fIL93sOTnEU+NrTAVMIKiAw0YH22HWCAgg4N4Z6zov2t0kY9RAJ50zY9ZMCQ+RT6bnOfDt8gCTnt/RaSNA2yRA==",
       "cpu": [
         "x64"
       ],
@@ -117,9 +133,9 @@
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.43.tgz",
-      "integrity": "sha512-bKS2BBFh+7XZY9rpjiHGRNA7LvWYbZWP87pLehggTG7tTaCDvj8qQGOU/OZSjCSKDYbgY7Q+oDw8RlYQ2Jt2BA==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.53.tgz",
+      "integrity": "sha512-PC7KaF1v0h/nWpvlU1UMN7dzB54cBH8qSsm7S9mkwFA1BXpaEOufCg8hdoEI1jep0KeO/rjZVWrsH8+q28T77A==",
       "cpu": [
         "arm64"
       ],
@@ -132,9 +148,9 @@
       }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.43.tgz",
-      "integrity": "sha512-/3PSilx011ttoieRGkSZ0XV8zjBf2C9enV4ScMMbCT4dpx0mFhMOpFnCHkOK0pWGB8LklykFyHrWk2z6DENVUg==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.53.tgz",
+      "integrity": "sha512-gE7P5wlnkX4d4PKvLBUgmhZXvL7lzGRLri17/+CmmCzfncIgq8lOBvxGMiQ4xazplhxq+72TEohyFMZLFxuWvg==",
       "cpu": [
         "x64"
       ],
@@ -147,9 +163,9 @@
       }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.43.tgz",
-      "integrity": "sha512-1HyFUKs8DMCBOvw1Qxpr5Vv/ThNcVIFb5xgXWK3pyT40WPvgYIiRTwJCvNs4l8i5qWF8/CK5bQxJVDjQvtv0Yw==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.53.tgz",
+      "integrity": "sha512-otJwDU3hnI15Q98PX4MJbknSZ/WSR1I45il7gcxcECXzfN4Mrpft5hBDHXNRnCh+5858uPXBXA1Vaz2jVWLaIA==",
       "cpu": [
         "arm64"
       ],
@@ -162,9 +178,9 @@
       }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.43.tgz",
-      "integrity": "sha512-FNWc05TPHYgaXjbPZO5/rJKSBslfG6BeMSs8GhwnqAKP56eEhvmzwnIz1QcC9cRVyO+IKqWNfmHFkCa1WJTULA==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.53.tgz",
+      "integrity": "sha512-WkdJa8iyrGHyKiPF4lk0MiOF87Q2SkE+i+8D4Cazq3/iqmGPJ6u49je300MFi5I2eUsQCkaOWhpCVQMTKGww2w==",
       "cpu": [
         "x64"
       ],
@@ -177,9 +193,9 @@
       }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.43.tgz",
-      "integrity": "sha512-amrYopclz3VohqisOPR6hA3GOWA3LZC1WDLnp21RhNmoERmJ/vLnOpnrG2P/Zao+/erKTCUqmrCIPVtj58DRoA==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.53.tgz",
+      "integrity": "sha512-9T7WwCuV30NAx0SyQpw8edbKvbKELnnm1FHg7gbSYaatH+c8WJW10g/OdM7JYnv7qkimw2ZTtSA+NokOLd2ydQ==",
       "cpu": [
         "arm64"
       ],
@@ -192,9 +208,9 @@
       }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.43.tgz",
-      "integrity": "sha512-KoxoEra+9O3AKVvgDFvDkiuddCds6q71owSQEYwjtqRV7RwbPzKxJa6+uyzUulHcyGVq0g15K0oKG5CFBcvYDw==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.53.tgz",
+      "integrity": "sha512-VGanLBg5en2LfGDgLEUxQko2lqsOS7MTEWUi8x91YmsHNyzJVT/WApbFFx3MQGhkf+XdimVhpyo5/G0PBY91zg==",
       "cpu": [
         "ia32"
       ],
@@ -207,9 +223,9 @@
       }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.43.tgz",
-      "integrity": "sha512-EwINwGMyiJMgBby5/SbMqKcUhS5AYAZ2CpEBzSowsJPNBJEdhkCTtEjk757TN/wxgbu3QklqDM6KghY660QCUw==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.53.tgz",
+      "integrity": "sha512-pP/FA55j/fzAV7N9DF31meAyjOH6Bjuo3aSKPh26+RW85ZEtbJv9nhoxmGTd9FOqjx59Tc1ZbrJabuiXlMwuZQ==",
       "cpu": [
         "x64"
       ],
@@ -222,9 +238,9 @@
       }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.43.tgz",
-      "integrity": "sha512-e6YzQUoDxxtyamuF12eVzzRC7bbEFSZohJ6igQB9tBqnNmIQY3fI6Cns3z2wxtbZ3f2o6idkD2fQnlvs2902Dg==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.53.tgz",
+      "integrity": "sha512-/u81NGAVZMopbmzd21Nu/wvnKQK3pT4CrvQ8BTje1STXcQAGnfyKgQlj3m0j2BzYbvQxSy+TMck4TNV2onvoPA==",
       "cpu": [
         "arm"
       ],
@@ -237,9 +253,9 @@
       }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.43.tgz",
-      "integrity": "sha512-UlSpjMWllAc70zYbHxWuDS3FJytyuR/gHJYBr8BICcTNb/TSOYVBg6U7b3jZ3mILTrgzwJUHwhEwK18FZDouUQ==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.53.tgz",
+      "integrity": "sha512-GDmWITT+PMsjCA6/lByYk7NyFssW4Q6in32iPkpjZ/ytSyH+xeEx8q7HG3AhWH6heemEYEWpTll/eui3jwlSnw==",
       "cpu": [
         "arm64"
       ],
@@ -252,9 +268,9 @@
       }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.43.tgz",
-      "integrity": "sha512-f+v8cInPEL1/SDP//CfSYzcDNgE4CY3xgDV81DWm3KAPWzhvxARrKxB1Pstf5mB56yAslJDxu7ryBUPX207EZA==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.53.tgz",
+      "integrity": "sha512-d6/XHIQW714gSSp6tOOX2UscedVobELvQlPMkInhx1NPz4ThZI9uNLQ4qQJHGBGKGfu+rtJsxM4NVHLhnNRdWQ==",
       "cpu": [
         "mips64el"
       ],
@@ -267,9 +283,9 @@
       }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.43.tgz",
-      "integrity": "sha512-5wZYMDGAL/K2pqkdIsW+I4IR41kyfHr/QshJcNpUfK3RjB3VQcPWOaZmc+74rm4ZjVirYrtz+jWw0SgxtxRanA==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.53.tgz",
+      "integrity": "sha512-ndnJmniKPCB52m+r6BtHHLAOXw+xBCWIxNnedbIpuREOcbSU/AlyM/2dA3BmUQhsHdb4w3amD5U2s91TJ3MzzA==",
       "cpu": [
         "ppc64"
       ],
@@ -282,9 +298,9 @@
       }
     },
     "node_modules/esbuild-linux-riscv64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.43.tgz",
-      "integrity": "sha512-lYcAOUxp85hC7lSjycJUVSmj4/9oEfSyXjb/ua9bNl8afonaduuqtw7hvKMoKuYnVwOCDw4RSfKpcnIRDWq+Bw==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.53.tgz",
+      "integrity": "sha512-yG2sVH+QSix6ct4lIzJj329iJF3MhloLE6/vKMQAAd26UVPVkhMFqFopY+9kCgYsdeWvXdPgmyOuKa48Y7+/EQ==",
       "cpu": [
         "riscv64"
       ],
@@ -297,9 +313,9 @@
       }
     },
     "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.43.tgz",
-      "integrity": "sha512-27e43ZhHvhFE4nM7HqtUbMRu37I/4eNSUbb8FGZWszV+uLzMIsHDwLoBiJmw7G9N+hrehNPeQ4F5Ujad0DrUKQ==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.53.tgz",
+      "integrity": "sha512-OCJlgdkB+XPYndHmw6uZT7jcYgzmx9K+28PVdOa/eLjdoYkeAFvH5hTwX4AXGLZLH09tpl4bVsEtvuyUldaNCg==",
       "cpu": [
         "s390x"
       ],
@@ -312,9 +328,9 @@
       }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.43.tgz",
-      "integrity": "sha512-2mH4QF6hHBn5zzAfxEI/2eBC0mspVsZ6UVo821LpAJKMvLJPBk3XJO5xwg7paDqSqpl7p6IRrAenW999AEfJhQ==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.53.tgz",
+      "integrity": "sha512-gp2SB+Efc7MhMdWV2+pmIs/Ja/Mi5rjw+wlDmmbIn68VGXBleNgiEZG+eV2SRS0kJEUyHNedDtwRIMzaohWedQ==",
       "cpu": [
         "x64"
       ],
@@ -327,9 +343,9 @@
       }
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.43.tgz",
-      "integrity": "sha512-ZhQpiZjvqCqO8jKdGp9+8k9E/EHSA+zIWOg+grwZasI9RoblqJ1QiZqqi7jfd6ZrrG1UFBNGe4m0NFxCFbMVbg==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.53.tgz",
+      "integrity": "sha512-eKQ30ZWe+WTZmteDYg8S+YjHV5s4iTxeSGhJKJajFfQx9TLZJvsJX0/paqwP51GicOUruFpSUAs2NCc0a4ivQQ==",
       "cpu": [
         "x64"
       ],
@@ -342,9 +358,9 @@
       }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.43.tgz",
-      "integrity": "sha512-DgxSi9DaHReL9gYuul2rrQCAapgnCJkh3LSHPKsY26zytYppG0HgkgVF80zjIlvEsUbGBP/GHQzBtrezj/Zq1Q==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.53.tgz",
+      "integrity": "sha512-OWLpS7a2FrIRukQqcgQqR1XKn0jSJoOdT+RlhAxUoEQM/IpytS3FXzCJM6xjUYtpO5GMY0EdZJp+ur2pYdm39g==",
       "cpu": [
         "x64"
       ],
@@ -357,9 +373,9 @@
       }
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.43.tgz",
-      "integrity": "sha512-Ih3+2O5oExiqm0mY6YYE5dR0o8+AspccQ3vIAtRodwFvhuyGLjb0Hbmzun/F3Lw19nuhPMu3sW2fqIJ5xBxByw==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.53.tgz",
+      "integrity": "sha512-m14XyWQP5rwGW0tbEfp95U6A0wY0DYPInWBB7D69FAXUpBpBObRoGTKRv36lf2RWOdE4YO3TNvj37zhXjVL5xg==",
       "cpu": [
         "ia32"
       ],
@@ -372,9 +388,9 @@
       }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.43.tgz",
-      "integrity": "sha512-8NsuNfI8xwFuJbrCuI+aBqNTYkrWErejFO5aYM+yHqyHuL8mmepLS9EPzAzk8rvfaJrhN0+RvKWAcymViHOKEw==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.53.tgz",
+      "integrity": "sha512-s9skQFF0I7zqnQ2K8S1xdLSfZFsPLuOGmSx57h2btSEswv0N0YodYvqLcJMrNMXh6EynOmWD7rz+0rWWbFpIHQ==",
       "cpu": [
         "x64"
       ],
@@ -387,9 +403,9 @@
       }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.43.tgz",
-      "integrity": "sha512-7ZlD7bo++kVRblJEoG+cepljkfP8bfuTPz5fIXzptwnPaFwGS6ahvfoYzY7WCf5v/1nX2X02HDraVItTgbHnKw==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.53.tgz",
+      "integrity": "sha512-E+5Gvb+ZWts+00T9II6wp2L3KG2r3iGxByqd/a1RmLmYWVsSVUjkvIxZuJ3hYTIbhLkH5PRwpldGTKYqVz0nzQ==",
       "cpu": [
         "arm64"
       ],
@@ -476,9 +492,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -608,11 +624,11 @@
       ]
     },
     "node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "dependencies": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -717,20 +733,20 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.9.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.12.tgz",
-      "integrity": "sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
+      "integrity": "sha512-NU304nqnBeOx2MkQnskBQxVsa0pRAH5FphokTGmyy8M3oxbvw7qAXts2GORxs+h/2vKsD+osMhZ7An6yK6F1dA==",
       "dependencies": {
-        "esbuild": "^0.14.27",
-        "postcss": "^8.4.13",
-        "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "esbuild": "^0.14.47",
+        "postcss": "^8.4.14",
+        "resolve": "^1.22.1",
+        "rollup": "^2.75.6"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": ">=12.2.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -738,7 +754,8 @@
       "peerDependencies": {
         "less": "*",
         "sass": "*",
-        "stylus": "*"
+        "stylus": "*",
+        "terser": "^5.4.0"
       },
       "peerDependenciesMeta": {
         "less": {
@@ -749,11 +766,20 @@
         },
         "stylus": {
           "optional": true
+        },
+        "terser": {
+          "optional": true
         }
       }
     }
   },
   "dependencies": {
+    "@esbuild/linux-loong64": {
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.53.tgz",
+      "integrity": "sha512-W2dAL6Bnyn4xa/QRSU3ilIK4EzD5wgYXKXJiS1HDF5vU3675qc2bvFyLwbUcdmssDveyndy7FbitrCoiV/eMLg==",
+      "optional": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -792,150 +818,151 @@
       }
     },
     "esbuild": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.43.tgz",
-      "integrity": "sha512-Uf94+kQmy/5jsFwKWiQB4hfo/RkM9Dh7b79p8yqd1tshULdr25G2szLz631NoH3s2ujnKEKVD16RmOxvCNKRFA==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.53.tgz",
+      "integrity": "sha512-ohO33pUBQ64q6mmheX1mZ8mIXj8ivQY/L4oVuAshr+aJI+zLl+amrp3EodrUNDNYVrKJXGPfIHFGhO8slGRjuw==",
       "requires": {
-        "esbuild-android-64": "0.14.43",
-        "esbuild-android-arm64": "0.14.43",
-        "esbuild-darwin-64": "0.14.43",
-        "esbuild-darwin-arm64": "0.14.43",
-        "esbuild-freebsd-64": "0.14.43",
-        "esbuild-freebsd-arm64": "0.14.43",
-        "esbuild-linux-32": "0.14.43",
-        "esbuild-linux-64": "0.14.43",
-        "esbuild-linux-arm": "0.14.43",
-        "esbuild-linux-arm64": "0.14.43",
-        "esbuild-linux-mips64le": "0.14.43",
-        "esbuild-linux-ppc64le": "0.14.43",
-        "esbuild-linux-riscv64": "0.14.43",
-        "esbuild-linux-s390x": "0.14.43",
-        "esbuild-netbsd-64": "0.14.43",
-        "esbuild-openbsd-64": "0.14.43",
-        "esbuild-sunos-64": "0.14.43",
-        "esbuild-windows-32": "0.14.43",
-        "esbuild-windows-64": "0.14.43",
-        "esbuild-windows-arm64": "0.14.43"
+        "@esbuild/linux-loong64": "0.14.53",
+        "esbuild-android-64": "0.14.53",
+        "esbuild-android-arm64": "0.14.53",
+        "esbuild-darwin-64": "0.14.53",
+        "esbuild-darwin-arm64": "0.14.53",
+        "esbuild-freebsd-64": "0.14.53",
+        "esbuild-freebsd-arm64": "0.14.53",
+        "esbuild-linux-32": "0.14.53",
+        "esbuild-linux-64": "0.14.53",
+        "esbuild-linux-arm": "0.14.53",
+        "esbuild-linux-arm64": "0.14.53",
+        "esbuild-linux-mips64le": "0.14.53",
+        "esbuild-linux-ppc64le": "0.14.53",
+        "esbuild-linux-riscv64": "0.14.53",
+        "esbuild-linux-s390x": "0.14.53",
+        "esbuild-netbsd-64": "0.14.53",
+        "esbuild-openbsd-64": "0.14.53",
+        "esbuild-sunos-64": "0.14.53",
+        "esbuild-windows-32": "0.14.53",
+        "esbuild-windows-64": "0.14.53",
+        "esbuild-windows-arm64": "0.14.53"
       }
     },
     "esbuild-android-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.43.tgz",
-      "integrity": "sha512-kqFXAS72K6cNrB6RiM7YJ5lNvmWRDSlpi7ZuRZ1hu1S3w0zlwcoCxWAyM23LQUyZSs1PbjHgdbbfYAN8IGh6xg==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.53.tgz",
+      "integrity": "sha512-fIL93sOTnEU+NrTAVMIKiAw0YH22HWCAgg4N4Z6zov2t0kY9RAJ50zY9ZMCQ+RT6bnOfDt8gCTnt/RaSNA2yRA==",
       "optional": true
     },
     "esbuild-android-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.43.tgz",
-      "integrity": "sha512-bKS2BBFh+7XZY9rpjiHGRNA7LvWYbZWP87pLehggTG7tTaCDvj8qQGOU/OZSjCSKDYbgY7Q+oDw8RlYQ2Jt2BA==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.53.tgz",
+      "integrity": "sha512-PC7KaF1v0h/nWpvlU1UMN7dzB54cBH8qSsm7S9mkwFA1BXpaEOufCg8hdoEI1jep0KeO/rjZVWrsH8+q28T77A==",
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.43.tgz",
-      "integrity": "sha512-/3PSilx011ttoieRGkSZ0XV8zjBf2C9enV4ScMMbCT4dpx0mFhMOpFnCHkOK0pWGB8LklykFyHrWk2z6DENVUg==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.53.tgz",
+      "integrity": "sha512-gE7P5wlnkX4d4PKvLBUgmhZXvL7lzGRLri17/+CmmCzfncIgq8lOBvxGMiQ4xazplhxq+72TEohyFMZLFxuWvg==",
       "optional": true
     },
     "esbuild-darwin-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.43.tgz",
-      "integrity": "sha512-1HyFUKs8DMCBOvw1Qxpr5Vv/ThNcVIFb5xgXWK3pyT40WPvgYIiRTwJCvNs4l8i5qWF8/CK5bQxJVDjQvtv0Yw==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.53.tgz",
+      "integrity": "sha512-otJwDU3hnI15Q98PX4MJbknSZ/WSR1I45il7gcxcECXzfN4Mrpft5hBDHXNRnCh+5858uPXBXA1Vaz2jVWLaIA==",
       "optional": true
     },
     "esbuild-freebsd-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.43.tgz",
-      "integrity": "sha512-FNWc05TPHYgaXjbPZO5/rJKSBslfG6BeMSs8GhwnqAKP56eEhvmzwnIz1QcC9cRVyO+IKqWNfmHFkCa1WJTULA==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.53.tgz",
+      "integrity": "sha512-WkdJa8iyrGHyKiPF4lk0MiOF87Q2SkE+i+8D4Cazq3/iqmGPJ6u49je300MFi5I2eUsQCkaOWhpCVQMTKGww2w==",
       "optional": true
     },
     "esbuild-freebsd-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.43.tgz",
-      "integrity": "sha512-amrYopclz3VohqisOPR6hA3GOWA3LZC1WDLnp21RhNmoERmJ/vLnOpnrG2P/Zao+/erKTCUqmrCIPVtj58DRoA==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.53.tgz",
+      "integrity": "sha512-9T7WwCuV30NAx0SyQpw8edbKvbKELnnm1FHg7gbSYaatH+c8WJW10g/OdM7JYnv7qkimw2ZTtSA+NokOLd2ydQ==",
       "optional": true
     },
     "esbuild-linux-32": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.43.tgz",
-      "integrity": "sha512-KoxoEra+9O3AKVvgDFvDkiuddCds6q71owSQEYwjtqRV7RwbPzKxJa6+uyzUulHcyGVq0g15K0oKG5CFBcvYDw==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.53.tgz",
+      "integrity": "sha512-VGanLBg5en2LfGDgLEUxQko2lqsOS7MTEWUi8x91YmsHNyzJVT/WApbFFx3MQGhkf+XdimVhpyo5/G0PBY91zg==",
       "optional": true
     },
     "esbuild-linux-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.43.tgz",
-      "integrity": "sha512-EwINwGMyiJMgBby5/SbMqKcUhS5AYAZ2CpEBzSowsJPNBJEdhkCTtEjk757TN/wxgbu3QklqDM6KghY660QCUw==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.53.tgz",
+      "integrity": "sha512-pP/FA55j/fzAV7N9DF31meAyjOH6Bjuo3aSKPh26+RW85ZEtbJv9nhoxmGTd9FOqjx59Tc1ZbrJabuiXlMwuZQ==",
       "optional": true
     },
     "esbuild-linux-arm": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.43.tgz",
-      "integrity": "sha512-e6YzQUoDxxtyamuF12eVzzRC7bbEFSZohJ6igQB9tBqnNmIQY3fI6Cns3z2wxtbZ3f2o6idkD2fQnlvs2902Dg==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.53.tgz",
+      "integrity": "sha512-/u81NGAVZMopbmzd21Nu/wvnKQK3pT4CrvQ8BTje1STXcQAGnfyKgQlj3m0j2BzYbvQxSy+TMck4TNV2onvoPA==",
       "optional": true
     },
     "esbuild-linux-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.43.tgz",
-      "integrity": "sha512-UlSpjMWllAc70zYbHxWuDS3FJytyuR/gHJYBr8BICcTNb/TSOYVBg6U7b3jZ3mILTrgzwJUHwhEwK18FZDouUQ==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.53.tgz",
+      "integrity": "sha512-GDmWITT+PMsjCA6/lByYk7NyFssW4Q6in32iPkpjZ/ytSyH+xeEx8q7HG3AhWH6heemEYEWpTll/eui3jwlSnw==",
       "optional": true
     },
     "esbuild-linux-mips64le": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.43.tgz",
-      "integrity": "sha512-f+v8cInPEL1/SDP//CfSYzcDNgE4CY3xgDV81DWm3KAPWzhvxARrKxB1Pstf5mB56yAslJDxu7ryBUPX207EZA==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.53.tgz",
+      "integrity": "sha512-d6/XHIQW714gSSp6tOOX2UscedVobELvQlPMkInhx1NPz4ThZI9uNLQ4qQJHGBGKGfu+rtJsxM4NVHLhnNRdWQ==",
       "optional": true
     },
     "esbuild-linux-ppc64le": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.43.tgz",
-      "integrity": "sha512-5wZYMDGAL/K2pqkdIsW+I4IR41kyfHr/QshJcNpUfK3RjB3VQcPWOaZmc+74rm4ZjVirYrtz+jWw0SgxtxRanA==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.53.tgz",
+      "integrity": "sha512-ndnJmniKPCB52m+r6BtHHLAOXw+xBCWIxNnedbIpuREOcbSU/AlyM/2dA3BmUQhsHdb4w3amD5U2s91TJ3MzzA==",
       "optional": true
     },
     "esbuild-linux-riscv64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.43.tgz",
-      "integrity": "sha512-lYcAOUxp85hC7lSjycJUVSmj4/9oEfSyXjb/ua9bNl8afonaduuqtw7hvKMoKuYnVwOCDw4RSfKpcnIRDWq+Bw==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.53.tgz",
+      "integrity": "sha512-yG2sVH+QSix6ct4lIzJj329iJF3MhloLE6/vKMQAAd26UVPVkhMFqFopY+9kCgYsdeWvXdPgmyOuKa48Y7+/EQ==",
       "optional": true
     },
     "esbuild-linux-s390x": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.43.tgz",
-      "integrity": "sha512-27e43ZhHvhFE4nM7HqtUbMRu37I/4eNSUbb8FGZWszV+uLzMIsHDwLoBiJmw7G9N+hrehNPeQ4F5Ujad0DrUKQ==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.53.tgz",
+      "integrity": "sha512-OCJlgdkB+XPYndHmw6uZT7jcYgzmx9K+28PVdOa/eLjdoYkeAFvH5hTwX4AXGLZLH09tpl4bVsEtvuyUldaNCg==",
       "optional": true
     },
     "esbuild-netbsd-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.43.tgz",
-      "integrity": "sha512-2mH4QF6hHBn5zzAfxEI/2eBC0mspVsZ6UVo821LpAJKMvLJPBk3XJO5xwg7paDqSqpl7p6IRrAenW999AEfJhQ==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.53.tgz",
+      "integrity": "sha512-gp2SB+Efc7MhMdWV2+pmIs/Ja/Mi5rjw+wlDmmbIn68VGXBleNgiEZG+eV2SRS0kJEUyHNedDtwRIMzaohWedQ==",
       "optional": true
     },
     "esbuild-openbsd-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.43.tgz",
-      "integrity": "sha512-ZhQpiZjvqCqO8jKdGp9+8k9E/EHSA+zIWOg+grwZasI9RoblqJ1QiZqqi7jfd6ZrrG1UFBNGe4m0NFxCFbMVbg==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.53.tgz",
+      "integrity": "sha512-eKQ30ZWe+WTZmteDYg8S+YjHV5s4iTxeSGhJKJajFfQx9TLZJvsJX0/paqwP51GicOUruFpSUAs2NCc0a4ivQQ==",
       "optional": true
     },
     "esbuild-sunos-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.43.tgz",
-      "integrity": "sha512-DgxSi9DaHReL9gYuul2rrQCAapgnCJkh3LSHPKsY26zytYppG0HgkgVF80zjIlvEsUbGBP/GHQzBtrezj/Zq1Q==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.53.tgz",
+      "integrity": "sha512-OWLpS7a2FrIRukQqcgQqR1XKn0jSJoOdT+RlhAxUoEQM/IpytS3FXzCJM6xjUYtpO5GMY0EdZJp+ur2pYdm39g==",
       "optional": true
     },
     "esbuild-windows-32": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.43.tgz",
-      "integrity": "sha512-Ih3+2O5oExiqm0mY6YYE5dR0o8+AspccQ3vIAtRodwFvhuyGLjb0Hbmzun/F3Lw19nuhPMu3sW2fqIJ5xBxByw==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.53.tgz",
+      "integrity": "sha512-m14XyWQP5rwGW0tbEfp95U6A0wY0DYPInWBB7D69FAXUpBpBObRoGTKRv36lf2RWOdE4YO3TNvj37zhXjVL5xg==",
       "optional": true
     },
     "esbuild-windows-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.43.tgz",
-      "integrity": "sha512-8NsuNfI8xwFuJbrCuI+aBqNTYkrWErejFO5aYM+yHqyHuL8mmepLS9EPzAzk8rvfaJrhN0+RvKWAcymViHOKEw==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.53.tgz",
+      "integrity": "sha512-s9skQFF0I7zqnQ2K8S1xdLSfZFsPLuOGmSx57h2btSEswv0N0YodYvqLcJMrNMXh6EynOmWD7rz+0rWWbFpIHQ==",
       "optional": true
     },
     "esbuild-windows-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.43.tgz",
-      "integrity": "sha512-7ZlD7bo++kVRblJEoG+cepljkfP8bfuTPz5fIXzptwnPaFwGS6ahvfoYzY7WCf5v/1nX2X02HDraVItTgbHnKw==",
+      "version": "0.14.53",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.53.tgz",
+      "integrity": "sha512-E+5Gvb+ZWts+00T9II6wp2L3KG2r3iGxByqd/a1RmLmYWVsSVUjkvIxZuJ3hYTIbhLkH5PRwpldGTKYqVz0nzQ==",
       "optional": true
     },
     "fast-glob": {
@@ -994,9 +1021,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -1069,11 +1096,11 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -1129,15 +1156,15 @@
       "dev": true
     },
     "vite": {
-      "version": "2.9.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.12.tgz",
-      "integrity": "sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
+      "integrity": "sha512-NU304nqnBeOx2MkQnskBQxVsa0pRAH5FphokTGmyy8M3oxbvw7qAXts2GORxs+h/2vKsD+osMhZ7An6yK6F1dA==",
       "requires": {
-        "esbuild": "^0.14.27",
+        "esbuild": "^0.14.47",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.13",
-        "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "postcss": "^8.4.14",
+        "resolve": "^1.22.1",
+        "rollup": "^2.75.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "fast-glob": "^3.2.11",
     "toml": "^3.0.0",
-    "vite": "^2.9.11"
+    "vite": "^3.0.4"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'vite';
+import { Plugin, PluginOption } from 'vite';
 import { resolve } from 'path';
 import { getHtmlPages, getHugoConfig } from './utils';
 
@@ -13,7 +13,7 @@ export interface Options {
      */
     appDir: string
 }
-export default function hugoPlugin({ hugoOutDir, appDir }: Options): Plugin {
+export default function hugoPlugin({ hugoOutDir, appDir }: Options): PluginOption {
     const hugoConfig = getHugoConfig(appDir);
 
     const ignoreBuildPaths: string[] = [];
@@ -23,7 +23,7 @@ export default function hugoPlugin({ hugoOutDir, appDir }: Options): Plugin {
         ignoreBuildPaths.push(resolve(hugoOutDir, hugoConfig.defaultContentLanguage));
     }
 
-    return {
+    const hugo : Plugin = {
         name: 'vite-plugin-hugo',
         config: () => ({
             root: hugoOutDir,
@@ -48,4 +48,6 @@ export default function hugoPlugin({ hugoOutDir, appDir }: Options): Plugin {
             }
         })
     }
+
+    return hugo
 }


### PR DESCRIPTION
Changed the type of the plugin function from `Plugin` to `PluginOption` due to changes in vite 3.0.0.

This may cause some typing issues when using `vite < 3.0.0`

There's simple workaround that shouldn't cause any isues, simply cast the hugoPlugin(..) to PluginOptions

e.g

```typescript
import { defineConfig, PluginOption } from 'vite';

// https://vitejs.dev/config/
export default defineConfig({
    plugins: [
        hugoPlugin({ appDir, hugoOutDir }) as PluginOption
    ]
});

```

